### PR TITLE
Provide 2.6 transparent compatibility.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -86,7 +86,9 @@ function local_loginas_extends_navigation(global_navigation $navigation) {
     }
 
     $coursecontext = context_course::instance($courseid);
-    if ($CFG->loginas_courseusers and !session_is_loggedinas() and has_capability('moodle/user:loginas', $coursecontext)) {
+    $loggedinas = method_exists('\core\session\manager', 'is_loggedinas') ?
+            \core\session\manager::is_loggedinas() : session_is_loggedinas();
+    if ($CFG->loginas_courseusers and !$loggedinas and has_capability('moodle/user:loginas', $coursecontext)) {
         if (!isset($loginas)) {
             $loginas = $settingsnav->add(get_string('loginas'));
         }


### PR DESCRIPTION
session_is_loggedinas() is deprecated for 2.6 and up. To avoid
developers getting debugging messages about that just verify if
the new method exists.
