### PR TITLE
Fixed deprecation warning, version bump.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') or die;
  * @param settings_navigation $settings The settings navigation object
  * @param stdClass $context The node context
  */
-function local_loginas_extends_settings_navigation(settings_navigation $settings, $context) {
+function local_loginas_extend_settings_navigation(settings_navigation $settings, $context) {
     global $DB, $CFG, $PAGE, $USER;
 
     // Course id and context.

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 defined('MOODLE_INTERNAL') or die;
 
 $plugin->component = 'local_loginas';
-$plugin->release = '2.8.0';
-$plugin->version = 2014111000;
+$plugin->release = '2.8.1';
+$plugin->version = 2015071400;
 $plugin->requires = 2014111000;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Moodle 2.9 was throwing a deprecation warning (a very simple one) which this PR fixes.
